### PR TITLE
Testing for backend API calls (using mock); add runtests.py.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 ._*
 *.pyc
+*.egg-info
 local.py

--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,21 @@ Just like Django's ``EmailMessage`` and ``EmailMultiAlternatives``, ``DjrillMess
 ``headers`` argument. Currently it only accepts ``Reply-To`` and ``X-*`` headers since that is all that Mandrill accepts. Any 
 extra headers are silently discarded.
 
+Testing
+-------
+
+The included tests verify that Djrill constructs the expected Mandrill API
+calls, without actually calling Mandrill or sending any email. So the tests
+don't require a Mandrill API key, but they *do* require mock_
+(``pip install mock``). To run the tests, either::
+
+    python setup.py test
+
+or::
+
+    python runtests.py
+
+
 Thanks
 ------
 
@@ -118,3 +133,4 @@ the awesome ``requests`` library.
 .. _MailChimp: http://mailchimp.com
 .. _requests: http://docs.python-requests.org
 .. _django-adminplus: https://github.com/jsocol/django-adminplus
+.. _mock: http://www.voidspace.org.uk/python/mock/index.html

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,35 @@
+# python setup.py test
+#   or
+# python runtests.py
+
+import sys
+from django.conf import settings
+
+APP='djrill'
+
+settings.configure(
+    DEBUG=True,
+    DATABASES={
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+        }
+    },
+    ROOT_URLCONF=APP+'.urls',
+    INSTALLED_APPS=(
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+        'django.contrib.sessions',
+        'django.contrib.admin',
+        APP,
+    )
+)
+
+from django.test.simple import DjangoTestSuiteRunner
+
+def runtests():
+    test_runner = DjangoTestSuiteRunner(verbosity=1)
+    failures = test_runner.run_tests([APP, ])
+    sys.exit(failures)
+
+if __name__ == '__main__':
+    runtests()

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ setup(
     zip_safe=False,
     install_requires=["requests", "django"],
     include_package_data=True,
+    test_suite="runtests.runtests",
+    test_requires=["mock"],
     classifiers=[
         "Programming Language :: Python",
         "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
This adds a base testcase that can be used to verify the backend generates the expected Mandrill API calls. It then uses this to add a test on Django's basic send_mail functionality with Djrill. (It mocks requests.post to avoid actually calling Mandrill. The base testcase is broken out separately to make it easy to add other tests as we start exposing other Mandrill functionality later.)

It also adds a "runtests.py" script that can be used to run the tests in isolation (without installing Djrill into another Django app) and documents this in the readme.

Cherry-picked from:
medmunds/Djrill@8c26807a: Add runtests.py for testing separately from other Django apps
medmunds/Djrill@cd8504b1: Make tests compatible with setuptools
medmunds/Djrill@4ac65b78: Set up testing on the backend API calls, using mock
