### PR TITLE
Provide a way to block admin.py when django-adminplus isn't loaded

### DIFF
--- a/djrill/admin.py
+++ b/djrill/admin.py
@@ -5,18 +5,25 @@ from djrill.views import (DjrillIndexView, DjrillSendersListView,
                           DjrillAddSenderView, DjrillTagListView,
                           DjrillUrlListView)
 
-admin.site.register_view("djrill/senders/", DjrillSendersListView.as_view(),
-    "djrill_senders", "senders")
-admin.site.register_view("djrill/status/", DjrillIndexView.as_view(),
-    "djrill_status", "status")
-admin.site.register_view("djrill/tags/", DjrillTagListView.as_view(),
-    "djrill_tags", "tags")
-admin.site.register_view("djrill/urls/", DjrillUrlListView.as_view(),
-    "djrill_urls", "urls")
+''' 
+This condition is set so wild 'admin.autodiscovers' don't call this admin.py 
+when we don't want it to and when django-adminplus isn't set, which is 
+colossally breaks the rest of the admins' sections.
+'''
+if hasattr(admin.site,'register_view'):
+    admin.site.register_view("djrill/senders/", DjrillSendersListView.as_view(),
+                             "djrill_senders", "senders")
+    admin.site.register_view("djrill/status/", DjrillIndexView.as_view(),
+						 	 "djrill_status", "status")
+    admin.site.register_view("djrill/tags/", DjrillTagListView.as_view(),
+							 "djrill_tags", "tags")
+    admin.site.register_view("djrill/urls/", DjrillUrlListView.as_view(),
+							 "djrill_urls", "urls")
 
-admin.site.register_url("djrill/disable/sender/",
-    DjrillDisableSenderView.as_view(), "djrill_disable_sender")
-admin.site.register_url("djrill/verify/sender/",
-    DjrillVerifySenderView.as_view(), "djrill_verify_sender")
-admin.site.register_url("djrill/add/sender/",
-    DjrillAddSenderView.as_view(), "djrill_add_sender")
+    admin.site.register_url("djrill/disable/sender/", DjrillDisableSenderView.as_view(), 
+							"djrill_disable_sender")
+    admin.site.register_url("djrill/verify/sender/",  DjrillVerifySenderView.as_view(), 
+							"djrill_verify_sender")
+    admin.site.register_url("djrill/add/sender/",	DjrillAddSenderView.as_view(), 
+							"djrill_add_sender")
+


### PR DESCRIPTION
I tried implementing _only_ Djrill's backend into my very large application, but the application's own admin.autodiscovers kept trying to register **DjrillAdminSite** which I was not interested in, giving me the following error:

```
File "/home/work/.virtualenvs/goodbed/lib/python2.7/site-packages/djrill/admin.py" in <module>
  8. admin.site.register_view("djrill/senders/", DjrillSendersListView.as_view(),
Exception Type: AttributeError at /
Exception Value: 'AdminSite' object has no attribute 'register_view'
```

So my fix for this was to check if adminplus' was installed (by checking for `register_view`), and if not (as is in my case), let it silently ignore the rest of its admin.py file.
