### PR TITLE
Remove obsolete admin related to sender verification

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,6 @@ email service from MailChimp_.
 An optional Django admin interface is included. The admin interface allows you to:
 
 * Check the status of your Mandrill API connection.
-* Add/disable email senders.
 * See stats on email tags and urls.
 
 Installation

--- a/djrill/admin.py
+++ b/djrill/admin.py
@@ -1,8 +1,7 @@
 from django.contrib import admin
 
 from djrill.views import (DjrillIndexView, DjrillSendersListView,
-                          DjrillDisableSenderView, DjrillVerifySenderView,
-                          DjrillAddSenderView, DjrillTagListView,
+                          DjrillTagListView,
                           DjrillUrlListView)
 
 admin.site.register_view("djrill/senders/", DjrillSendersListView.as_view(),
@@ -13,10 +12,3 @@ admin.site.register_view("djrill/tags/", DjrillTagListView.as_view(),
     "djrill_tags", "tags")
 admin.site.register_view("djrill/urls/", DjrillUrlListView.as_view(),
     "djrill_urls", "urls")
-
-admin.site.register_url("djrill/disable/sender/",
-    DjrillDisableSenderView.as_view(), "djrill_disable_sender")
-admin.site.register_url("djrill/verify/sender/",
-    DjrillVerifySenderView.as_view(), "djrill_verify_sender")
-admin.site.register_url("djrill/add/sender/",
-    DjrillAddSenderView.as_view(), "djrill_add_sender")

--- a/djrill/forms.py
+++ b/djrill/forms.py
@@ -1,7 +1,0 @@
-from django import forms
-from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
-
-
-class CreateSenderForm(forms.Form):
-    email = forms.EmailField()

--- a/djrill/templates/djrill/senders_list.html
+++ b/djrill/templates/djrill/senders_list.html
@@ -39,32 +39,8 @@
 
 {% block content %}
   <div id="content-main">
-    {% block object-tools %}
-      {% if has_add_permission %}
-        <ul class="object-tools">
-          {% block object-tools-items %}
-            <li>
-              <a href="add/{% if is_popup %}?_popup=1{% endif %}" class="addlink">
-                {% blocktrans %}Add sender{% endblocktrans %}
-              </a>
-            </li>
-          {% endblock %}
-        </ul>
-      {% endif %}
-    {% endblock %}
 
     <div class="module filtered" id="changelist">
-        {% block search %}
-        <div id="toolbar">
-            <form action="{% url "admin:djrill_add_sender" %}" method="POST">
-                <label for="id_email" class="addlink">Add a new sender</label>
-                <input type="email" placeholder="E-mail address" name="email" id="id_email">
-                {% csrf_token %}
-                <input type="submit" value="Submit">
-            </form>
-        </div>
-        {% endblock %}
-
         {% block date_hierarchy %}{% endblock %}
 
       {% block filters %}
@@ -80,7 +56,6 @@
                         {% for header in objects.0.keys %}
                         <th scope="col">{{ header|capfirst }}</th>
                         {% endfor %}
-                        <th></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -89,21 +64,6 @@
                         {% for item in result.values %}
                             <td>{{ item }}</td>
                         {% endfor %}
-                        <td>
-                            {% if result.is_enabled and result.approved_at %}
-                            <form method="POST" action="{% url "admin:djrill_disable_sender" %}">
-                            {% else %}
-                            <form method="POST" action="{% url "admin:djrill_verify_sender" %}">
-                            {% endif %}
-                                <input type="hidden" name="email" value="{{ result.address }}">
-                                {% csrf_token %}
-                                {% if result.is_enabled and result.approved_at %}
-                                <button>disable</buton>
-                                {% else %}
-                                <button>enable</buton>
-                                {% endif %}
-                            </form>
-                        </td>
                     </tr>
                 {% endfor %}
                 </tbody>

--- a/djrill/templates/djrill/tags_list.html
+++ b/djrill/templates/djrill/tags_list.html
@@ -39,19 +39,6 @@
 
 {% block content %}
   <div id="content-main">
-    {% block object-tools %}
-      {% if has_add_permission %}
-        <ul class="object-tools">
-          {% block object-tools-items %}
-            <li>
-              <a href="add/{% if is_popup %}?_popup=1{% endif %}" class="addlink">
-                {% blocktrans %}Add sender{% endblocktrans %}
-              </a>
-            </li>
-          {% endblock %}
-        </ul>
-      {% endif %}
-    {% endblock %}
 
     <div class="module filtered" id="changelist">
         {% block search %} {% endblock %}

--- a/djrill/templates/djrill/urls_list.html
+++ b/djrill/templates/djrill/urls_list.html
@@ -39,19 +39,6 @@
 
 {% block content %}
   <div id="content-main">
-    {% block object-tools %}
-      {% if has_add_permission %}
-        <ul class="object-tools">
-          {% block object-tools-items %}
-            <li>
-              <a href="add/{% if is_popup %}?_popup=1{% endif %}" class="addlink">
-                {% blocktrans %}Add sender{% endblocktrans %}
-              </a>
-            </li>
-          {% endblock %}
-        </ul>
-      {% endif %}
-    {% endblock %}
 
     <div class="module filtered" id="changelist">
         {% block search %}{% endblock %}


### PR DESCRIPTION
This removes the admin form for adding new verified senders and the enable/disable sender buttons in the admin sender list. (Since Mandrill no longer has the concept of verifying senders, the APIs it used are no longer offered.)
