### PR TITLE
Note BSD license in readme and setup.py package classifiers.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,8 @@ An optional Django admin interface is included. The admin interface allows you t
 * Add/disable email senders.
 * See stats on email tags and urls.
 
+Djrill is made available under the BSD license.
+
 Installation
 ------------
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     include_package_data=True,
     classifiers=[
         "Programming Language :: Python",
+        "License :: OSI Approved :: BSD License",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Framework :: Django",
         "Environment :: Web Environment",


### PR DESCRIPTION
Just confirming that Drjill is under the BSD license. (I'm assuming so based on the line `license="BSD"` found in setup.py.)

The setup.py change will cause the license to be listed in PyPI.
