### PR TITLE
Configure travis-ci.org tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+env:
+  - DJANGO_VERSION=1.3
+  - DJANGO_VERSION=1.4
+install:
+  - pip install -q Django==$DJANGO_VERSION
+  - pip install . --use-mirrors
+script: python setup.py test

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,10 @@
 Djrill, for Mandrill
 ====================
 
-Djrill is an email backend and new message class for Django users that want to take advantage of the Mandrill_ transactional 
+.. image:: https://travis-ci.org/brack3t/Djrill.png
+        :target: https://secure.travis-ci.org/brack3t/Djrill
+
+Djrill is an email backend and new message class for Django users that want to take advantage of the Mandrill_ transactional
 email service from MailChimp_.
 
 An optional Django admin interface is included. The admin interface allows you to:
@@ -109,6 +112,13 @@ extra headers are silently discarded.
 
 Testing
 -------
+
+Djrill is tested against Django 1.3 and 1.4 on Python 2.6 and 2.7.
+(It may also work with Django 1.2 and Python 2.5, if you use an older
+version of requests compatible with that code.)
+
+.. image:: https://travis-ci.org/brack3t/Djrill.png
+        :target: https://secure.travis-ci.org/brack3t/Djrill
 
 The included tests verify that Djrill constructs the expected Mandrill API
 calls, without actually calling Mandrill or sending any email. So the tests


### PR DESCRIPTION
This includes configuration needed to have travis-ci.org automatically run the tests and display their status in the readme.

You would first want to enable brack3t/Djrill for Travis, using the instructions at http://about.travis-ci.org/docs/user/getting-started/. Only steps 1 and 2 are needed -- the remaining steps are covered by this pull request.

---

Travis CI: Test Django 1.2 and 1.3; Python 2.6 and 2.7

Don't bother testing Python 2.5 -- it requires an older version of requests (that doesn't depend on json).

Don't bother testing Django 1.2 -- it requires changes to `assertRaises` in the test cases (because the context-manager version of assertRaises is part of unittest2, which is part of Django 1.3+ or Python 2.7+).

Don't bother testing Django 1.5 (yet) -- wait for it to show up in PyPI.
