### PR TITLE
Don't filter attachment types

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,10 +144,7 @@ Djrill supports most of the functionality of Django's `EmailMessage`_ and
   for logging. To send a single message to multiple recipients without exposing
   their email addresses to each other, simply include them all in the "to" list
   and leave ``preserve_recipients`` set to False.)
-* **Attachments:** Djrill includes a message's attachments, but only with the
-  mimetypes "text/\*", "image/\*", or "application/pdf" (since that is all
-  Mandrill allows). Any other attachment types will raise
-  ``djrill.NotSupportedByMandrillError`` when you attempt to send the message.
+* **Attachments:** Djrill includes a message's attachments.
 * **Headers:** Djrill accepts additional headers, but only ``Reply-To`` and
   ``X-*`` (since that is all that Mandrill accepts). Any other extra headers
   will raise ``djrill.NotSupportedByMandrillError`` when you attempt to send the

--- a/djrill/mail/backends/djrill.py
+++ b/djrill/mail/backends/djrill.py
@@ -233,18 +233,6 @@ class DjrillBackend(BaseEmailBackend):
         if mimetype is None:
             mimetype = DEFAULT_ATTACHMENT_MIME_TYPE
 
-        # Mandrill silently filters attachments with unsupported mimetypes.
-        # This can be confusing, so we raise an exception instead.
-        (main, sub) = mimetype.lower().split('/')
-        attachment_allowed = (
-            main == 'text' or main == 'image'
-            or (main == 'application' and sub == 'pdf'))
-        if not attachment_allowed:
-            raise NotSupportedByMandrillError(
-                "Invalid attachment mimetype '%s'. Mandrill only supports "
-                "text/*, image/*, and application/pdf attachments."
-                % mimetype)
-
         try:
             content_b64 = b64encode(content)
         except TypeError:


### PR DESCRIPTION
Mandrill dropped filtering on attachment mimetypes, so stop enforcing this in Djrill.
Fixes #26
