### PR TITLE
Support inline_css

### DIFF
--- a/djrill/mail/backends/djrill.py
+++ b/djrill/mail/backends/djrill.py
@@ -144,7 +144,7 @@ class DjrillBackend(BaseEmailBackend):
         # Mandrill attributes that can be copied directly:
         mandrill_attrs = [
             'from_name', # overrides display name parsed from from_email above
-            'track_opens', 'track_clicks', 'auto_text', 'url_strip_qs',
+            'track_opens', 'track_clicks', 'auto_text', 'inline_css', 'url_strip_qs',
             'tags', 'preserve_recipients',
             'google_analytics_domains', 'google_analytics_campaign',
             'metadata']

--- a/djrill/tests/test_mandrill_send.py
+++ b/djrill/tests/test_mandrill_send.py
@@ -296,10 +296,12 @@ class DjrillMandrillFeatureTests(DjrillBackendMockAPITestCase):
 
     def test_message_options(self):
         self.message.auto_text = True
+        self.message.inline_css = True
         self.message.preserve_recipients = True
         self.message.send()
         data = self.get_api_call_data()
         self.assertEqual(data['message']['auto_text'], True)
+        self.assertEqual(data['message']['inline_css'], True)
         self.assertEqual(data['message']['preserve_recipients'], True)
 
     def test_merge(self):
@@ -375,6 +377,7 @@ class DjrillMandrillFeatureTests(DjrillBackendMockAPITestCase):
         self.assertFalse('track_opens' in data['message'])
         self.assertFalse('track_clicks' in data['message'])
         self.assertFalse('auto_text' in data['message'])
+        self.assertFalse('inline_css' in data['message'])
         self.assertFalse('url_strip_qs' in data['message'])
         self.assertFalse('tags' in data['message'])
         self.assertFalse('preserve_recipients' in data['message'])

--- a/docs/usage/sending_mail.rst
+++ b/docs/usage/sending_mail.rst
@@ -132,6 +132,13 @@ Most of the options from the Mandrill
     ``Boolean``: whether Mandrill should automatically generate a text body from the HTML.
     Default from your Mandrill account settings.
 
+.. attribute:: inline_css
+
+    ``Boolean``: whether Mandrill should inline CSS styles in the HTML.
+    Default from your Mandrill account settings.
+
+    .. versionadded:: 0.4
+
 .. attribute:: url_strip_qs
 
     ``Boolean``: whether Mandrill should ignore any query parameters when aggregating


### PR DESCRIPTION
Mandrill added an option to inline css in html email. Djrill should expose that option.
