### PR TITLE
Security fix: Changes the default API endpoint to the https version

### DIFF
--- a/djrill/__init__.py
+++ b/djrill/__init__.py
@@ -9,7 +9,7 @@ from ._version import *
 # This backend was developed against this API endpoint.
 # You can override in settings.py, if desired.
 MANDRILL_API_URL = getattr(settings, "MANDRILL_API_URL",
-    "http://mandrillapp.com/api/1.0")
+    "https://mandrillapp.com/api/1.0")
 
 
 class DjrillAdminSite(AdminSite):


### PR DESCRIPTION
While the previous http endpoint that was used by default does redirect to the https version, I think it would be a lot safer to not depend on that.
Also, and correct me if I'm wrong, but by the time we receive the redirect response from the server we have already sent of the payload in plain-text http for any man-in-the-middle to read?