### PR TITLE
Sender email address as ugettext_lazy object breaks Djrill

### DIFF
--- a/djrill/mail/backends/djrill.py
+++ b/djrill/mail/backends/djrill.py
@@ -2,6 +2,8 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.mail.backends.base import BaseEmailBackend
 from django.core.mail.message import sanitize_address, DEFAULT_ATTACHMENT_MIME_TYPE
+from django.utils.encoding import force_text
+from django.utils.functional import Promise
 
 # Oops: this file has the same name as our app, and cannot be renamed.
 #from djrill import MANDRILL_API_URL, MandrillAPIError, NotSupportedByMandrillError
@@ -138,7 +140,10 @@ class DjrillBackend(BaseEmailBackend):
         Raises NotSupportedByMandrillError for any standard EmailMessage
         features that cannot be accurately communicated to Mandrill.
         """
-        sender = sanitize_address(message.from_email, message.encoding)
+        sender = message.from_email
+        if isinstance(sender, Promise):
+            sender = force_text(sender, message.encoding)
+        sender = sanitize_address(sender, message.encoding)
         from_name, from_email = parseaddr(sender)
 
         to_list = self._make_mandrill_to_list(message, message.to, "to")

--- a/djrill/mail/backends/djrill.py
+++ b/djrill/mail/backends/djrill.py
@@ -2,8 +2,12 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.mail.backends.base import BaseEmailBackend
 from django.core.mail.message import sanitize_address, DEFAULT_ATTACHMENT_MIME_TYPE
-from django.utils.encoding import force_text
 from django.utils.functional import Promise
+
+try:
+    from django.utils.encoding import force_text
+except ImportError:
+    from django.utils.encoding import force_unicode as force_text
 
 # Oops: this file has the same name as our app, and cannot be renamed.
 #from djrill import MANDRILL_API_URL, MandrillAPIError, NotSupportedByMandrillError


### PR DESCRIPTION
Defining sender email as ugettext_lazy object breaks the Djrill backend:

    File "/opt/lib/python2.7/site-packages/djrill/mail/backends/djrill.py", line 68, in send_messages
        sent = self._send(message)
    File "/opt/lib/python2.7/site-packages/djrill/mail/backends/djrill.py", line 85, in _send
        msg_dict = self._build_standard_message_dict(message)
    File "/opt/lib/python2.7/site-packages/djrill/mail/backends/djrill.py", line 141, in _build_standard_message_dict
        sender = sanitize_address(message.from_email, message.encoding)
    File "/opt/lib/python2.7/site-packages/django/core/mail/message.py", line 105, in sanitize_address
        nm, addr = addr
    ValueError: too many values to unpack

Forcing the value to be evaluated before it is being broken into pieces seems to fix the issue.