### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 Djrill is maintained by its users. Your contributions are encouraged!
 
-Please see [Contributing](https://djrill.readthedocs.org/en/latest/contributing/)
+Please see [Contributing](https://djrill.readthedocs.io/en/latest/contributing/)
 in the Djrill documentation for more information.

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Djrill uses `semantic versioning <http://semver.org/>`_.
 
 **Resources**
 
-* Full documentation: https://djrill.readthedocs.org/en/latest/
+* Full documentation: https://djrill.readthedocs.io/en/latest/
 * Package on PyPI: https://pypi.python.org/pypi/djrill
 * Project on Github: https://github.com/brack3t/Djrill
 
@@ -125,5 +125,5 @@ Djrill 1-2-3
 .. END quickstart
 
 
-See the `full documentation <https://djrill.readthedocs.org/en/latest/>`_
+See the `full documentation <https://djrill.readthedocs.io/en/latest/>`_
 for more features and options.

--- a/djrill/tests/test_mandrill_send.py
+++ b/djrill/tests/test_mandrill_send.py
@@ -213,7 +213,7 @@ class DjrillBackendTests(DjrillBackendMockAPITestCase):
             to=['to1@example.com'],
         )
         # Slight modification from the Django unicode docs:
-        # http://django.readthedocs.org/en/latest/ref/unicode.html#email
+        # https://django.readthedocs.io/en/latest/ref/unicode.html#email
         msg.attach("Une pièce jointe.html", '<p>\u2019</p>', mimetype='text/html')
 
         msg.send()

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -120,7 +120,7 @@ Version 0.4:
 * New Mandrill :attr:`inline_css` option is supported
 * Remove limitations on attachment types, to track Mandrill change
 * Documentation is now available on
-  `djrill.readthedocs.org <https://djrill.readthedocs.org>`_
+  `djrill.readthedocs.org <https://djrill.readthedocs.io>`_
 
 
 Version 0.3:


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.