### PR TITLE
docs: Fix simple typo, ovveride -> override

### DIFF
--- a/djrill/tests/test_mandrill_send.py
+++ b/djrill/tests/test_mandrill_send.py
@@ -631,7 +631,7 @@ class DjrillRecipientsRefusedTests(DjrillBackendMockAPITestCase):
     'invalid': 'invalid',
 })
 class DjrillMandrillGlobalFeatureTests(DjrillBackendMockAPITestCase):
-    """Test Djrill backend support for global ovveride Mandrill-specific features"""
+    """Test Djrill backend support for global override Mandrill-specific features"""
 
     def setUp(self):
         super(DjrillMandrillGlobalFeatureTests, self).setUp()


### PR DESCRIPTION
There is a small typo in djrill/tests/test_mandrill_send.py.

Should read `override` rather than `ovveride`.

